### PR TITLE
Update code for CEF 124

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ find_package(CEF REQUIRED)
 # we only bother with UNICODE builds on Windows
 if(MSVC)
 	add_definitions(-DUNICODE -D_UNICODE)
+	add_compile_options("/std:c++latest")
 endif()
 
 set(

--- a/cmake/cef_variables.cmake
+++ b/cmake/cef_variables.cmake
@@ -198,18 +198,15 @@ if(OS_LINUX)
   set(CEF_BINARY_FILES
     chrome-sandbox
     libcef.so
-    natives_blob.bin
     snapshot_blob.bin
     v8_context_snapshot.bin
     )
 
   # List of CEF resource files.
   set(CEF_RESOURCE_FILES
-    cef.pak
-    cef_100_percent.pak
-    cef_200_percent.pak
-    cef_extensions.pak
-    devtools_resources.pak
+    chrome_100_percent.pak
+    chrome_200_percent.pak
+    resources.pak
     icudtl.dat
     locales
     )
@@ -419,24 +416,19 @@ if(OS_WINDOWS)
   # List of CEF binary files.
   set(CEF_BINARY_FILES
     chrome_elf.dll
-    d3dcompiler_43.dll
     d3dcompiler_47.dll
     libcef.dll
     libEGL.dll
     libGLESv2.dll
-    natives_blob.bin
     snapshot_blob.bin
     v8_context_snapshot.bin
-    swiftshader
     )
 
   # List of CEF resource files.
   set(CEF_RESOURCE_FILES
-    cef.pak
-    cef_100_percent.pak
-    cef_200_percent.pak
-    cef_extensions.pak
-    devtools_resources.pak
+    chrome_100_percent.pak
+    chrome_200_percent.pak
+    resources.pak
     icudtl.dat
     locales
     )

--- a/gen_vs2022.bat
+++ b/gen_vs2022.bat
@@ -1,0 +1,15 @@
+@echo off
+
+rem set CEF_ROOT=c:\cef\cef_binary_3.3325.1742.g5caccda_windows64
+
+set BASE_DIR=%~dp0
+rem echo %BASE_DIR%
+
+mkdir "%BASE_DIR%\build"
+
+cd "%BASE_DIR%\build"
+
+rem Visual Studio 2022
+cmake -G "Visual Studio 17" -A x64 "%BASE_DIR%"
+
+cd %BASE_DIR%

--- a/src/d3d11.cpp
+++ b/src/d3d11.cpp
@@ -359,7 +359,7 @@ namespace d3d11 {
 		return "n/a";
 	}
 
-	shared_ptr<Context> Device::immedidate_context()
+	shared_ptr<Context> Device::immediate_context()
 	{
 		return ctx_;
 	}

--- a/src/d3d11.cpp
+++ b/src/d3d11.cpp
@@ -280,7 +280,7 @@ namespace d3d11 {
 	{
 	}
 
-	void* Texture2D::share_handle() const
+	HANDLE Texture2D::share_handle() const
 	{
 		return share_handle_;
 	}
@@ -329,7 +329,7 @@ namespace d3d11 {
 		}
 	}
 
-	Device::Device(ID3D11Device* pdev, ID3D11DeviceContext* pctx)
+	Device::Device(ID3D11Device1* pdev, ID3D11DeviceContext* pctx)
 		: device_(to_com_ptr(pdev))
 		, ctx_(make_shared<Context>(pctx))
 	{
@@ -573,10 +573,10 @@ namespace d3d11 {
 		return nullptr;
 	}
 
-	shared_ptr<Texture2D> Device::open_shared_texture(void* handle)
+	shared_ptr<Texture2D> Device::open_shared_texture(HANDLE handle)
 	{
 		ID3D11Texture2D* tex = nullptr;
-		auto hr = device_->OpenSharedResource(
+		auto hr = device_->OpenSharedResource1(
 				handle, __uuidof(ID3D11Texture2D), (void**)(&tex));
 		if (FAILED(hr)) {
 			return nullptr;
@@ -839,6 +839,7 @@ float4 main(VS_OUTPUT input) : SV_Target
 
 		
 		ID3D11Device* pdev = nullptr;
+		ID3D11Device1* pdev1 = nullptr;
 		ID3D11DeviceContext* pctx = nullptr;
 
 		D3D_FEATURE_LEVEL selected_level;
@@ -872,7 +873,9 @@ float4 main(VS_OUTPUT input) : SV_Target
 		
 		if (SUCCEEDED(hr)) 
 		{
-			auto const dev = make_shared<Device>(pdev, pctx);
+			pdev->QueryInterface<ID3D11Device1>(&pdev1);
+
+			auto const dev = make_shared<Device>(pdev1, pctx);
 
 			log_message("d3d11: selected adapter: %s\n", dev->adapter_name().c_str());
 

--- a/src/d3d11.cpp
+++ b/src/d3d11.cpp
@@ -875,9 +875,12 @@ float4 main(VS_OUTPUT input) : SV_Target
 		}
 		
 		if (SUCCEEDED(hr)) 
-		{
-			pdev->QueryInterface<ID3D11Device1>(&pdev1);
+			hr = pdev->QueryInterface<ID3D11Device1>(&pdev1);
 
+		pdev->Release();
+
+		if (SUCCEEDED(hr))
+		{
 			auto const dev = make_shared<Device>(pdev1, pctx);
 
 			log_message("d3d11: selected adapter: %s\n", dev->adapter_name().c_str());

--- a/src/d3d11.h
+++ b/src/d3d11.h
@@ -58,7 +58,7 @@ namespace d3d11 {
 			return device_.get();
 		}
 
-		std::shared_ptr<Context> immedidate_context();
+		std::shared_ptr<Context> immediate_context();
 
 		std::shared_ptr<SwapChain> create_swapchain(HWND, int width=0, int height=0);
 		

--- a/src/d3d11.h
+++ b/src/d3d11.h
@@ -131,7 +131,8 @@ namespace d3d11 {
 	public:
 		Texture2D(
 			ID3D11Texture2D* tex,
-			ID3D11ShaderResourceView* srv);
+			ID3D11ShaderResourceView* srv,
+			HANDLE share_handle = nullptr);
 
 		void bind(std::shared_ptr<Context> const& ctx);
 		void unbind();

--- a/src/d3d11.h
+++ b/src/d3d11.h
@@ -50,11 +50,11 @@ namespace d3d11 {
 	class Device
 	{
 	public:
-		Device(ID3D11Device*, ID3D11DeviceContext*);
+		Device(ID3D11Device1*, ID3D11DeviceContext*);
 
 		std::string adapter_name() const;
 
-		operator ID3D11Device*() {
+		operator ID3D11Device1*() {
 			return device_.get();
 		}
 
@@ -72,7 +72,7 @@ namespace d3d11 {
 					const void* data,
 					size_t row_stride);
 
-		std::shared_ptr<Texture2D> open_shared_texture(void*);
+		std::shared_ptr<Texture2D> open_shared_texture(HANDLE);
 
 		std::shared_ptr<Effect> create_default_effect();
 
@@ -93,7 +93,7 @@ namespace d3d11 {
 
 		HMODULE _lib_compiler;
 
-		std::shared_ptr<ID3D11Device> const device_;
+		std::shared_ptr<ID3D11Device1> const device_;
 		std::shared_ptr<Context> const ctx_;
 	};
 
@@ -145,7 +145,7 @@ namespace d3d11 {
 		bool lock_key(uint64_t key, uint32_t timeout_ms);
 		void unlock_key(uint64_t key);
 
-		void* share_handle() const;
+		HANDLE share_handle() const;
 
 		void copy_from(std::shared_ptr<Texture2D> const&);
 		

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,7 +148,7 @@ public:
 
 	void render()
 	{
-		auto ctx = device_->immedidate_context();
+		auto ctx = device_->immediate_context();
 		if (!ctx || !swapchain_) {
 			return;
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -405,7 +405,9 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, LPWSTR, int)
 
 	// default to webgl aquarium demo
 	if (url.empty()) {
-		url = "https://webglsamples.org/aquarium/aquarium.html";
+		//url = "https://webglsamples.org/aquarium/aquarium.html";
+		//url = "https://webglsamples.org/blob/blob.html";
+		url = "https://www.youtube.com/watch?v=7oAjnqu_wxE";
 	}
 	if (width <= 0) {
 		width = 1280;

--- a/src/web_layer.cpp
+++ b/src/web_layer.cpp
@@ -241,7 +241,7 @@ public:
 	// CefRenderProcessHandler::OnProcessMessageReceived
 	//
 	bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
-		CefRefPtr<CefFrame> frame,
+		CefRefPtr<CefFrame> /*frame*/,
 		CefProcessId /*source_process*/,
 		CefRefPtr<CefProcessMessage> message) override
 	{

--- a/src/web_layer.cpp
+++ b/src/web_layer.cpp
@@ -145,7 +145,7 @@ public:
 			// notify the browser process that we want stats
 			auto message = CefProcessMessage::Create("mixer-request-stats");
 			if (message != nullptr && browser_ != nullptr) {
-				//browser_->SendProcessMessage(PID_BROWSER, message);
+				browser_->GetFocusedFrame()->SendProcessMessage(PID_BROWSER, message);
 			}
 			return true;
 		}
@@ -241,8 +241,9 @@ public:
 	// CefRenderProcessHandler::OnProcessMessageReceived
 	//
 	bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
+		CefRefPtr<CefFrame> frame,
 		CefProcessId /*source_process*/,
-		CefRefPtr<CefProcessMessage> message) 
+		CefRefPtr<CefProcessMessage> message) override
 	{
 		auto const name = message->GetName().ToString();
 		if (name == "mixer-update-stats")
@@ -484,8 +485,9 @@ public:
 
 	bool OnProcessMessageReceived(
 		CefRefPtr<CefBrowser> /*browser*/,
+		CefRefPtr<CefFrame> /*frame*/,
 		CefProcessId /*source_process*/,
-		CefRefPtr<CefProcessMessage> message) //override
+		CefRefPtr<CefProcessMessage> message) override
 	{
 		auto name = message->GetName().ToString();
 		if (name == "mixer-request-stats")
@@ -790,7 +792,7 @@ public:
 
 		args->SetDictionary(0, dict);
 
-		//browser->SendProcessMessage(PID_RENDERER, message);
+		browser->GetFocusedFrame()->SendProcessMessage(PID_RENDERER, message);
 	}
 
 	void resize(int width, int height)


### PR DESCRIPTION
In CEF 124, a new accelerated painting interface was introduced, using SHARED_NT handles now, via Direct3D 11.1.
The code has been modified to work with the newer CEF release.
As a quick-and-dirty patch, it makes the code render again, and it avoids the obvious exceptions and other issues.
However, this may not be the preferred way to use the new interface. Currently the shared textures are used directly, but their lifetime may not be guaranteed outside the OnAcceleratedPaint()-callback, so it may be better to make a copy inside the OnAcceleratedPaint(), and then use the copy for rendering.